### PR TITLE
Added support for Swedish

### DIFF
--- a/R/toOrdinal.R
+++ b/R/toOrdinal.R
@@ -15,7 +15,7 @@ function(
 
 	### Argument tests
 
-	supported_languages_ordinal_number <- c("ENGLISH", "FRENCH", "GERMAN", "SPANISH")
+	supported_languages_ordinal_number <- c("ENGLISH", "FRENCH", "GERMAN", "SPANISH", "SWEDISH")
 	supported_languages_ordinal_word <- "" 
 	if (floor(cardinal_number)!=cardinal_number | cardinal_number < 1) stop("Number supplied to 'toOrdinal' must be a positive integer.", call.=FALSE)
 
@@ -70,6 +70,19 @@ function(
 			tmp <- strtail(as.character(cardinal_number), 1)
 			if (tmp %in% c('1', '3')) tmp.suffix <- ".er"
 			if (tmp %in% c('0', '2', '4', '5', '6', '7', '8', '9')) tmp.suffix <- ".\u00BA"
+		}
+
+   
+		### SWEDISH
+		
+		if (toupper(language)=="SWEDISH") {
+		 	tmp_1char <- strtail(as.character(cardinal_number), 1)
+		 	tmp_2char <- strtail(as.character(cardinal_number), 2)
+		 	if (tmp_1char %in% c('0', '3', '4', '5', '6', '7', '8', '9') | tmp_2char %in% c('11', '12')) { 
+				tmp.suffix <- ":e"
+			} else if (tmp_1char %in% c('1', '2')) {
+				tmp.suffix <- ":a"
+			}
 		}
 
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ a pull request with the additional specifications for other languages.
 [![Build Status](https://travis-ci.org/CenterForAssessment/toOrdinal.svg?branch=master)](https://travis-ci.org/CenterForAssessment/toOrdinal) [![Join the chat at https://gitter.im/CenterForAssessment/toOrdinal](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/CenterForAssessment/toOrdinal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![License](http://img.shields.io/badge/license-GPL%203-brightgreen.svg?style=flat)](https://github.com/CenterForAssessment/toOrdinal/blob/master/LICENSE.md)
 
 
-Currently the package implements English, French and German. For example,
+Currently the package implements English, French, German, Spanish, and Swedish. For example,
 
 * English: toOrdinal(1) returns '1st'
 * German: toOrdinal(1, language="German") returns '1te'
 * French: toOrdinal(1, language="French") returns '1re'
+* Spanish: toOrdinal(1, language="Spanish") returns '1.er'
+* Swedish: toOrdinal(1, language="Swedish") returns '1:a'
 
 To install the latest stable release from [CRAN](http://cran.r-project.org/package=toOrdinal)
 ---------------------------

--- a/tests/testthat/test_toOrdinal_swedish.R
+++ b/tests/testthat/test_toOrdinal_swedish.R
@@ -1,0 +1,31 @@
+context("Swedish tests")
+
+test_that("toOrdinal correctly processes integers 1-40 in Swedish", {
+  first_40 <- c("1:a", "2:a", "3:e", "4:e", "5:e", "6:e", "7:e", "8:e", "9:e", 
+    "10:e", "11:e", "12:e", "13:e", "14:e", "15:e", "16:e", "17:e", 
+    "18:e", "19:e", "20:e", "21:a", "22:a", "23:e", "24:e", "25:e", 
+    "26:e", "27:e", "28:e", "29:e", "30:e", "31:a", "32:a", "33:e", 
+    "34:e", "35:e", "36:e", "37:e", "38:e", "39:e", "40:e")
+  using_toOrdinal <- sapply(c(1:40), "toOrdinal", language="swedish")
+  
+  expect_equal(
+    first_40, using_toOrdinal  
+  )
+})
+
+test_that("toOrdinal correctly processes integers 101, 102, 111, and 112 in Swedish", {
+  adtl_nums <- c("101:a", "102:a", "111:e", "112:e")
+  using_toOrdinal <- sapply(c(101, 102, 111, 112), "toOrdinal", language="swedish")
+  
+  expect_equal(
+    adtl_nums, using_toOrdinal  
+  )
+})
+
+test_that("toOrdinal correctly errors when given a negative integer.",{
+  
+  expect_error(
+    toOrdinal(-1), "Error : Number supplied to 'toOrdinal' must be a positive integer.\\n"   
+  )
+})
+


### PR DESCRIPTION
I've added support for Swedish ordinals (1:a, 2:a, 3:e, etc.).
