### PR TITLE
Fix toOrdinal() and the test for Dutch

### DIFF
--- a/R/toOrdinal_Utility_Functions.R
+++ b/R/toOrdinal_Utility_Functions.R
@@ -21,13 +21,16 @@ function(cardinal_number,
 		# Suffix handling by language
 		suffix <- switch(toupper(language),
 			"DUTCH" = {
-				suffix <- if (cardinal_number %% 100 >= 11 && cardinal_number %% 100 <= 19) {
-					"de" # Numbers from 11 to 19 always use "de"
-				} else if (cardinal_number %% 10 == 1 || cardinal_number %% 10 == 8 || cardinal_number %% 10 == 0) {
-					"ste" # Numbers ending in 1, 8, or 0 use "ste"
-				} else {
-					"de" # All other cases use "de"
-				}
+				# Take the number formed by the last two digits of the cardinal number
+				tmp_2int <- cardinal_number %% 100 
+				# Suffix defaults to 'ste' with a couple of exceptions where the suffix is 'de':
+				# 	the cardinal number is exactly 0, or 
+				#	the number formed by the last the two digits is smaller than 20, but not equal to 1 or 8.
+				suffix <- if ((cardinal_number == 0 || (tmp_2int > 1 && tmp_2int < 20)) && tmp_2int != 8) {
+                			'de'
+               		      } else {
+                 			'ste'
+               			  }
 			},
 			"ENGLISH" = {
 				tmp <- strTail(as.character(cardinal_number), 2)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ toOrdinal
 # Overview
 
 The R package **toOrdinal** contains a single function `toOrdinal` that converts a cardinal number (e.g., 9) into its ordinal counterpart (e.g., 9th).
-Because such conversions are language specific, the conversions are specific to a supported language. At present, the package implements English, 
+Because such conversions are language specific, the conversions are specific to a supported language. At present, the package implements English, Dutch,
 French, German, Spanish, and Swedish. For example,
 
 * English: toOrdinal(1) returns '1st'
@@ -47,6 +47,9 @@ To install the development release of **toOrdinal** from [GitHub](https://github
 ```
 > toOrdinal(5)
 [1] "5th"
+
+> toOrdinal(5, language="Dutch")
+[1] "5de"
 
 > toOrdinal(5, language="German")
 [1] "5te"

--- a/tests/testthat/test_toOrdinal_dutch.R
+++ b/tests/testthat/test_toOrdinal_dutch.R
@@ -1,14 +1,23 @@
 context("Dutch tests")
 
 test_that("toOrdinal correctly processes integers 0-30 in Dutch", {
-  first_30 <- c("0ste", "1ste", "2de", "3de", "4de", "5de", "6de", "7de", "8ste",
-                "9de", "10ste", "11de", "12de", "13de", "14de", "15de", "16de",
-                "17de", "18de", "19de", "20ste", "21ste", "22de", "23de",
-                "24de", "25de", "26de", "27de", "28ste", "29de", "30ste")
-  using_toOrdinal <- sapply(0:30, "toOrdinal", "DUTCH")
+  first_30 <- c("0de", "1ste", "2de", "3de", "4de", "5de", "6de", "7de", "8ste",
+                "9de", "10de", "11de", "12de", "13de", "14de", "15de", "16de",
+                "17de", "18de", "19de", "20ste", "21ste", "22ste", "23ste",
+                "24ste", "25ste", "26ste", "27ste", "28ste", "29ste", "30ste")
+  using_toOrdinal <- sapply(0:30, "toOrdinal", language="DUTCH")
 
   expect_equal(
     first_30, using_toOrdinal
+  )
+})
+
+test_that("toOrdinal correctly processes integers 100, 101, 102, 108, 120 in Dutch", {
+  above_hundred <- c("100ste", "101ste", "102de", "108ste",'120ste') # 101de and 101ste are both acceptable, but 101ste is more common
+  using_toOrdinal <- sapply(c(100, 101, 102, 108, 120), "toOrdinal", language="DUTCH")
+
+  expect_equal(
+    above_hundred, using_toOrdinal
   )
 })
 


### PR DESCRIPTION
The way the suffix for Dutch ordinals is calculated didn't give the right results for certain numbers.
The test in  [test_toOrdinal_dutch.R](https://github.com/CenterForAssessment/toOrdinal/blob/c7b42489e83e00221d68aebebdbdb7c16883ecf8/tests/testthat/test_toOrdinal_dutch.R) contained the wrong suffix for the numbers 0, 10, 22:27 and 29. 

One of the tricky bits is that the suffix for 0 ('de') differs from the suffixes for 100 ('ste'). 
I rewrote the logic for calculating the suffix and added some comments.
I also added a test for some numbers >= 100.